### PR TITLE
Avoid data file corruption by flushing to disk

### DIFF
--- a/recthread.c
+++ b/recthread.c
@@ -136,7 +136,9 @@ void write_file(struct rec_thread_context *ctx, uint64_t time_stamp,
     fprintf(stderr, "WARNING: could not write out sig spectra\n");
 
   fflush(fp);
-
+  if (fdatasync(fileno(fp))) {
+    perror("fdatasync()");
+  }
 }
 
 


### PR DESCRIPTION
Power failures (which are frequent at some locations) can lead to data file corruption because the file was not flushed to disk. `fdatasync()` is now used to flush the file.
